### PR TITLE
Update PHP version to 5.6.

### DIFF
--- a/puppet_manifests/default.pp
+++ b/puppet_manifests/default.pp
@@ -28,9 +28,13 @@ class folders {
 }
 
 class updates {
-    exec { "aptitude-update":
-        command => "/usr/bin/aptitude update -y -q",
-        timeout => 0
+    exec {
+        "add-php-repository":
+            command => '/usr/bin/add-apt-repository -y ppa:ondrej/php5-5.6',
+            timeout => 0;
+        "aptitude-update":
+            command => "/usr/bin/aptitude update -y -q",
+            timeout => 0;
     }
 }
 


### PR DESCRIPTION
Updates php to be 5.6, the newest version supported on Acquia cloud, instead of 5.5.
