### PR TITLE
Update Console Table download to use github instead of download.pear.php.net.

### DIFF
--- a/puppet_manifests/default.pp
+++ b/puppet_manifests/default.pp
@@ -144,13 +144,13 @@ class php {
             require => Exec['php-download-drush'];
 
         "console-table-download":
-            command => '/usr/bin/wget http://download.pear.php.net/package/Console_Table-1.1.3.tgz',
-            unless => '/bin/ls /usr/share/php/drush/lib/Console_Table-1.1.3';
+            command => '/usr/bin/wget https://github.com/pear/Console_Table/archive/Console_Table-1.1.6.tar.gz',
+            unless => '/bin/ls /usr/share/php/drush/lib/Console_Table-Console_Table-1.1.6';
         "console-table-untar":
-            command => '/bin/tar -zxvf Console_Table-1.1.3.tgz',
+            command => '/bin/tar -zxvf Console_Table-1.1.6.tar.gz',
             require => Exec['console-table-download'];
         "console-table-install":
-            command => '/bin/cp -r Console_Table-1.1.3 /opt/drush/lib/',
+            command => '/bin/cp -r Console_Table-Console_Table-1.1.6 /opt/drush/lib/',
             require => Exec['console-table-untar'];
 
         "memcached-bind-address":


### PR DESCRIPTION
The download URL has been unresponsive and giving me errors. This bumps the version from 1.1.3 to 1.1.6 but uses Github as the source which is more reliable.
